### PR TITLE
Proposal: RouteResolver

### DIFF
--- a/src/CompassServiceProvider.php
+++ b/src/CompassServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Davidhsianturi\Compass\Contracts\ApiDocsRepository;
 use Davidhsianturi\Compass\Contracts\RequestRepository;
 use Davidhsianturi\Compass\Contracts\ResponseRepository;
+use Davidhsianturi\Compass\Contracts\RouteResolverContract;
 use Davidhsianturi\Compass\Storage\DatabaseRequestRepository;
 use Davidhsianturi\Compass\Storage\DatabaseResponseRepository;
 
@@ -104,6 +105,7 @@ class CompassServiceProvider extends ServiceProvider
 
         $this->registerStorageDriver();
         $this->registerTemplateBuilder();
+        $this->registerRouteResolver();
 
         $this->commands([
             Console\InstallCommand::class,
@@ -170,6 +172,18 @@ class CompassServiceProvider extends ServiceProvider
     {
         $this->app->singleton(
             ApiDocsRepository::class, SlateBuilder::class
+        );
+    }
+
+    /**
+     * Register the package slate builder.
+     *
+     * @return void
+     */
+    protected function registerRouteResolver()
+    {
+        $this->app->singleton(
+            RouteResolverContract::class, RouteResolver::class
         );
     }
 }

--- a/src/Contracts/RouteResolverContract.php
+++ b/src/Contracts/RouteResolverContract.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Davidhsianturi\Compass\Contracts;
+
+use Illuminate\Routing\Route;
+
+interface RouteResolverContract
+{   
+    /**
+     * Retrieve title from the route
+     *
+     * @param Route $route
+     *
+     * @return string
+     */
+    public function getTitle(Route $route);
+
+    /**
+     * Retrieve description from the route
+     *
+     * @param Route $route
+     *
+     * @return string
+     */
+    public function getDescription(Route $route);
+
+}

--- a/src/Contracts/RouteResolverContract.php
+++ b/src/Contracts/RouteResolverContract.php
@@ -7,7 +7,7 @@ use Illuminate\Routing\Route;
 interface RouteResolverContract
 {   
     /**
-     * Retrieve title from the route
+     * Retrieve title from the route.
      *
      * @param Route $route
      *
@@ -16,7 +16,7 @@ interface RouteResolverContract
     public function getTitle(Route $route);
 
     /**
-     * Retrieve description from the route
+     * Retrieve description from the route.
      *
      * @param Route $route
      *

--- a/src/Contracts/RouteResolverContract.php
+++ b/src/Contracts/RouteResolverContract.php
@@ -5,7 +5,7 @@ namespace Davidhsianturi\Compass\Contracts;
 use Illuminate\Routing\Route;
 
 interface RouteResolverContract
-{   
+{
     /**
      * Retrieve title from the route.
      *
@@ -23,5 +23,4 @@ interface RouteResolverContract
      * @return string
      */
     public function getDescription(Route $route);
-
 }

--- a/src/RouteResolver.php
+++ b/src/RouteResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Davidhsianturi\Compass;
+
+use Illuminate\Support\Str;
+use Illuminate\Routing\Route;
+use Davidhsianturi\Compass\Contracts\RouteResolverContract;
+
+class RouteResolver implements RouteResolverContract
+{
+    /**
+     * Retrieve title from the route
+     *
+     * @param Route $route
+     *
+     * @return string
+     */
+    public function getTitle(Route $route)
+    {
+        $baseUri = config('compass.routes.base_uri');
+
+        return Str::after($route->uri(), $baseUri);
+    }
+
+    /**
+     * Retrieve description from the route
+     *
+     * @param Route $route
+     *
+     * @return string
+     */
+    public function getDescription(Route $route)
+    {
+        return null;
+    }
+}

--- a/src/RouteResolver.php
+++ b/src/RouteResolver.php
@@ -9,7 +9,7 @@ use Davidhsianturi\Compass\Contracts\RouteResolverContract;
 class RouteResolver implements RouteResolverContract
 {
     /**
-     * Retrieve title from the route
+     * Retrieve title from the route.
      *
      * @param Route $route
      *
@@ -23,7 +23,7 @@ class RouteResolver implements RouteResolverContract
     }
 
     /**
-     * Retrieve description from the route
+     * Retrieve description from the route.
      *
      * @param Route $route
      *
@@ -31,6 +31,6 @@ class RouteResolver implements RouteResolverContract
      */
     public function getDescription(Route $route)
     {
-        return null;
+        return '';
     }
 }


### PR DESCRIPTION
For a various of reason i need to customize the endpoints of all routes.

For instance i wish the name to be displayed differently than

```php
$baseUri = config('compass.routes.base_uri');
return Str::after($route->uri(), $baseUri);
```

in something more like this
```php
ucfirst(last(explode(".", $route->getName())));
```
but others will think about this differently.

I think it should be possibile to customize [this](https://github.com/davidhsianturi/laravel-compass/blob/master/src/Compass.php#L38) and that's why i have added a RouteResolver. 