### PR TITLE
add support for sub-domain routing

### DIFF
--- a/resources/js/axios-instance.js
+++ b/resources/js/axios-instance.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 
-const instance = axios.create({
-    baseURL: Compass.app.base_url
-});
+const instance = axios.create();
 
 instance.interceptors.request.use((config) => {
     config.timing = {

--- a/resources/js/pages/cortex.vue
+++ b/resources/js/pages/cortex.vue
@@ -57,6 +57,20 @@ export default {
         }
     },
 
+    computed: {
+        baseUrl() {
+            let appUrl = new URL(Compass.app.base_url);
+            let newHostname = this.requestData.info.domain;
+
+            if (!newHostname) {
+                return appUrl.origin
+            };
+
+            appUrl.hostname = newHostname;
+            return appUrl.origin;
+        }
+    },
+
     mounted() {
         axios.get('/' + Compass.path + '/request/' + this.id).then(response => {
             this.fillRequest(response.data);
@@ -77,7 +91,7 @@ export default {
             this.requestData.info.domain = data.info.domain;
             this.requestData.info.methods = data.info.methods;
             this.requestData.content.url = data.content.url || data.info.uri;
-            this.requestData.content.body = data.content.body || this.newFormRequests();
+            this.requestData.content.body = data.content.body;
             this.requestData.content.headers = data.content.headers || this.newFormRequests();
             this.requestData.content.selectedMethod = data.content.selectedMethod || data.info.methods[0];
         },
@@ -95,6 +109,7 @@ export default {
             contentType = contentType ? contentType.value : null
 
             this.http({
+                baseURL: this.baseUrl,
                 url: this.requestData.content.url,
                 method: this.requestData.content.selectedMethod,
                 headers: this.filterFormRequests(this.requestData.content.headers),


### PR DESCRIPTION
This PR included code changes to add support for [Laravel sub-domain routing](https://laravel.com/docs/6.x/routing#route-group-sub-domain-routing).

You can access Compass to test the endpoints in your sub-domain routing in two ways.

1. without CORS header support in your project.
`http://sub-domain.yourproject.test/compass`

2. with CORS header support in your project.
`http://yourproject.test/compass`

<hr>

Closes #31, closes #51 