### PR TITLE
Auth tabs.

### DIFF
--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -90,6 +90,21 @@ export default {
         },
 
         /**
+         * Normalize headers with the given auth.
+         *
+         * @param {Array} entries
+         * @param {Object} auth
+         * @return {Object}
+         */
+        toRequestHeaders(entries, auth) {
+            const authInStorage = localStorage.getItem(auth.key);
+            const token = authInStorage ? JSON.parse(authInStorage).token : '';
+            const authHeader = { Authorization: `${auth.type} ${token}` };
+            const headers = this.filterFormRequests(entries);
+            return auth.type === 'Bearer' ? { ...headers, ...authHeader } : headers;
+        },
+
+        /**
          * The mouseOver/mouseOut event target in element.
          */
         activateElmnt(val) {

--- a/resources/js/components/Authenticator.vue
+++ b/resources/js/components/Authenticator.vue
@@ -1,0 +1,53 @@
+<script>
+import None from './request/auth/None';
+import Bearer from './request/auth/Bearer';
+
+export default {
+    components: {
+        None,
+        Bearer
+    },
+
+    props: {
+        authType: {
+            type: String,
+            required: true
+        },
+        authKey: {
+            type: String,
+            required: true
+        }
+    },
+
+    data() {
+        return {
+            currentTab: this.authType,
+            tabs: ['None', 'Bearer']
+        }
+    },
+
+    watch: {
+        currentTab(val) {
+            this.$emit('update:auth-type', val);
+        }
+    }
+}
+</script>
+
+<template>
+    <div>
+        <ul class="flex inline-block ml-4 text-xs text-gray-600">
+            <li class="-mb-px mr-4 py-3" v-for="(tab, i) in tabs" :key="i">
+                <input
+                    type="radio"
+                    name="tab"
+                    :id="`tab-${tab}`"
+                    :value="tab"
+                    v-model="currentTab">
+                <label class="lowercase" :for="`tab-${tab}`">{{tab}}</label>
+            </li>
+        </ul>
+
+        <component :is="currentTab" :auth-key="authKey" class="border-t border-gray-200" />
+    </div>
+</template>

--- a/resources/js/components/RequestTabs.vue
+++ b/resources/js/components/RequestTabs.vue
@@ -71,6 +71,9 @@ export default {
         },
         requestBodyKeys() {
             return REQUEST_BODY_KEYS
+        },
+        ignoreAuth() {
+            return Compass.app.env !== 'local';
         }
     },
 
@@ -170,7 +173,7 @@ export default {
                         href="#"
                         @click.prevent="currentTab='body'">Body</a>
                 </li>
-                <li class="-mb-px mr-1" v-if="okToSend">
+                <li class="-mb-px mr-1" v-if="okToSend && !ignoreAuth">
                     <a :class="{'text-gray-800 border-primary border-b-2': currentTab=='auth'}"
                         class="inline-block text-sm py-2 px-4 text-gray-600 hover:text-gray-800"
                         href="#"
@@ -246,7 +249,7 @@ export default {
                     </div>
                 </div>
             </template>
-            <template v-if="currentTab=='auth'">
+            <template v-if="currentTab=='auth' && !ignoreAuth">
                 <authenticator :auth-type.sync="authType" :auth-key="authKey" />
             </template>
             <template v-if="currentTab=='route'">

--- a/resources/js/components/RequestTabs.vue
+++ b/resources/js/components/RequestTabs.vue
@@ -2,6 +2,7 @@
 import Dropdown from './Dropdown';
 import DataTable from './DataTable';
 import CodeEditor from './CodeEditor';
+import Authenticator from './Authenticator';
 import BodyOptions from './request/BodyOptions';
 import { REQUEST_BODY_KEYS } from '../constants';
 
@@ -10,7 +11,8 @@ export default {
         Dropdown,
         DataTable,
         CodeEditor,
-        BodyOptions
+        BodyOptions,
+        Authenticator
     },
 
     props: {
@@ -25,12 +27,17 @@ export default {
         okToSend: {
             type: Boolean,
             default: true
+        },
+        authKey: {
+            type: String,
+            required: true
         }
     },
 
     data() {
         return {
             currentTab: 'headers',
+            authType: this.request.content.authType,
             headers: [ ...this.request.content.headers ],
             headerContentType: null,
             headerContentTypeIndex: -1,
@@ -54,14 +61,14 @@ export default {
                 title: this.about.title,
                 description: this.about.description,
                 content: {
-                    url: this.request.content.url,
                     headers: this.headers,
+                    authType: this.authType,
+                    url: this.request.content.url,
                     body: this.body[this.bodyOption.value],
-                    selectedMethod: this.request.content.selectedMethod,
+                    selectedMethod: this.request.content.selectedMethod
                 }
             }
         },
-
         requestBodyKeys() {
             return REQUEST_BODY_KEYS
         }
@@ -93,6 +100,12 @@ export default {
             }
         },
         about: {
+            deep: true,
+            handler() {
+                this.$emit('update:request', this.requestData);
+            }
+        },
+        authType: {
             deep: true,
             handler() {
                 this.$emit('update:request', this.requestData);
@@ -156,6 +169,12 @@ export default {
                         class="inline-block text-sm py-2 px-4 text-gray-600 hover:text-gray-800"
                         href="#"
                         @click.prevent="currentTab='body'">Body</a>
+                </li>
+                <li class="-mb-px mr-1" v-if="okToSend">
+                    <a :class="{'text-gray-800 border-primary border-b-2': currentTab=='auth'}"
+                        class="inline-block text-sm py-2 px-4 text-gray-600 hover:text-gray-800"
+                        href="#"
+                        @click.prevent="currentTab='auth'">Auth</a>
                 </li>
                 <li class="-mb-px mr-1">
                     <a :class="{'text-gray-800 border-primary border-b-2': currentTab=='route'}"
@@ -226,6 +245,9 @@ export default {
                         <span class="text-xs text-gray-500">This request does not have a body</span>
                     </div>
                 </div>
+            </template>
+            <template v-if="currentTab=='auth'">
+                <authenticator :auth-type.sync="authType" :auth-key="authKey" />
             </template>
             <template v-if="currentTab=='route'">
                 <table class="w-full text-left table-collapse">

--- a/resources/js/components/request/auth/Bearer.vue
+++ b/resources/js/components/request/auth/Bearer.vue
@@ -1,0 +1,146 @@
+<script>
+import axios from 'axios';
+import selectOptions from 'vue-multiselect';
+
+export default {
+    components: {
+        selectOptions
+    },
+
+    props: {
+        authKey: {
+            type: String,
+            required: true
+        }
+    },
+
+    data() {
+        return {
+            auths: [],
+            selectedAuth: null
+        }
+    },
+
+    mounted() {
+        this.loadAuths();
+        this.loadSelectedAuth();
+    },
+
+    methods: {
+        loadAuths() {
+            let auths = this.getItem('auths');
+            if (auths) this.auths = auths;
+        },
+        loadSelectedAuth() {
+            let selectedAuth = this.getItem(this.authKey);
+            if (selectedAuth) this.selectedAuth = selectedAuth;
+        },
+        saveAuth(val) {
+            let newAuth = val ? [val] : [];
+            let oldAuth = this.auths;
+            const uKey = 'token'; // unique key.
+            // update old auth or create a new one.
+            let auths = [...newAuth, ...oldAuth].reduce((acc, cur) => !acc.filter(n => cur[uKey] === n[uKey]).length ? [...acc, cur] : acc, []);
+            this.setItem('auths', auths);
+        },
+        onAddAuth(val) {
+            let newAuth = {token: '', name: val};
+            this.selectedAuth ? this.selectedAuth.name = val : this.selectedAuth = newAuth;
+            this.$refs.token.focus();
+        },
+        onInputToken(val) {
+            let newAuth = {token: val, name: this.selectedAuth ? this.selectedAuth.name : 'unknown'};
+            let oldUser = this.auths.find(user => user.token === val);
+            this.selectedAuth = oldUser || newAuth;
+        },
+        onRemoveAuth(val) {
+            this.auths.splice(val, 1);
+            this.removeItem(this.authKey);
+            this.saveAuth();
+        },
+        setItem(key, value) {
+            try {
+                localStorage.setItem(key, JSON.stringify(value));
+            } catch (e) {
+                console.log(e);
+            }
+        },
+        getItem(key) {
+            const itemInStorage = localStorage.getItem(key);
+
+            if (itemInStorage) {
+                try {
+                    return JSON.parse(itemInStorage);
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+
+            return;
+        },
+        removeItem(key) {
+            try {
+                localStorage.removeItem(key);
+            } catch (e) {
+                console.log(e);
+            }
+        }
+    },
+
+    watch: {
+        selectedAuth: {
+            deep: true,
+            handler(val) {
+                if (val) {
+                    this.setItem(this.authKey, val)
+                    this.saveAuth(val)
+                }
+            }
+        }
+    }
+}
+</script>
+
+<template>
+    <table class="w-full text-left table-collapse">
+        <thead>
+            <tr>
+                <th class="border-b border-r border-gray-200 text-xs font-semibold text-gray-700 w-auto"></th>
+                <th class="p-2 border-b border-r border-gray-200 text-xs font-semibold text-gray-700 w-1/3">Name</th>
+                <th class="p-2 b border-b border-gray-200 text-xs font-semibold text-gray-700 w-2/3">Token</th>
+            </tr>
+        </thead>
+        <tbody class="align-baseline">
+            <tr>
+                <td class="px-4 border-r border-gray-200 text-xs text-gray-800 text-right"></td>
+                <td class="p-0 border-r border-gray-200 text-xs text-gray-800">
+                    <select-options
+                        class="hide-arrow-icon"
+                        v-model="selectedAuth"
+                        openDirection="bottom"
+                        tag-placeholder="Add this as new auth"
+                        placeholder="Search or add a new auth"
+                        label="name"
+                        select-label="Select auth"
+                        deselect-label="Remove from this request"
+                        track-by="token"
+                        :show-no-results="false"
+                        :options="auths"
+                        :taggable="true"
+                        @open="loadAuths"
+                        @remove="onRemoveAuth"
+                        @tag="onAddAuth" />
+                </td>
+                <td class="pl-2 border-gray-200 text-xs text-gray-800 relative">
+                    <input
+                        class="appearance-none focus:outline-none w-full bg-transparent"
+                        ref="token"
+                        type="text"
+                        placeholder="Select from the list or paste here to create a new one"
+                        :value="selectedAuth ? selectedAuth.token : ''"
+                        @input="onInputToken($event.target.value)">
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</template>

--- a/resources/js/components/request/auth/None.vue
+++ b/resources/js/components/request/auth/None.vue
@@ -1,0 +1,18 @@
+<script>
+export default {
+    props: {
+        authKey: {
+            type: String,
+            required: true
+        }
+    }
+}
+</script>
+
+<template>
+    <div class="w-full px-3 py-2 text-center">
+        <span class="text-xs text-gray-500">
+            No authorization was set for this request
+        </span>
+    </div>
+</template>

--- a/resources/js/pages/cortex.vue
+++ b/resources/js/pages/cortex.vue
@@ -27,13 +27,14 @@ export default {
                     name: '',
                     action: '',
                     domain: '',
-                    methods: [],
+                    methods: []
                 },
                 content: {
                     url: '',
                     body: [],
                     headers: [],
                     selectedMethod: '',
+                    authType: ''
                 },
             },
             responseReady: false,
@@ -68,6 +69,12 @@ export default {
 
             appUrl.hostname = newHostname;
             return appUrl.origin;
+        },
+        authenticator() {
+            let type = this.requestData.content.authType;
+            let key = `${type}@${this.requestData.id}`;
+
+            return {type, key};
         }
     },
 
@@ -90,8 +97,9 @@ export default {
             this.requestData.info.action = data.info.action;
             this.requestData.info.domain = data.info.domain;
             this.requestData.info.methods = data.info.methods;
-            this.requestData.content.url = data.content.url || data.info.uri;
             this.requestData.content.body = data.content.body;
+            this.requestData.content.url = data.content.url || data.info.uri;
+            this.requestData.content.authType = data.content.authType || 'None';
             this.requestData.content.headers = data.content.headers || this.newFormRequests();
             this.requestData.content.selectedMethod = data.content.selectedMethod || data.info.methods[0];
         },
@@ -110,7 +118,7 @@ export default {
                 baseURL: this.baseUrl,
                 url: this.requestData.content.url,
                 method: this.requestData.content.selectedMethod,
-                headers: this.filterFormRequests(this.requestData.content.headers),
+                headers: this.toRequestHeaders(this.requestData.content.headers, this.authenticator),
                 data: this.toRequestData(this.requestData.content.body, contentType),
             }).then(response => {
                 this.fillResponse(response);
@@ -168,6 +176,7 @@ export default {
                 class="bg-secondary"
                 :request.sync="requestData"
                 :examples="requestData.examples"
+                :authKey="authenticator.key"
                 @request-data-ready="saveRequest" />
 
             <div v-if="!responseReady">

--- a/src/Compass.php
+++ b/src/Compass.php
@@ -5,6 +5,7 @@ namespace Davidhsianturi\Compass;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
@@ -126,6 +127,7 @@ final class Compass
             'app' => [
                 'name' => config('app.name'),
                 'base_url' => config('app.url'),
+                'env' => App::environment(),
             ],
         ];
     }


### PR DESCRIPTION
This PR adds the auth tabs that can be used to make authorized requests. Compass will automatically include the auth data to the chosen auth type. so far only support `Bearer` token, 
and the auth data can be reusable to all available requests.

<img width="831" alt="Screen Shot 2020-02-14 at 22 51 27" src="https://user-images.githubusercontent.com/26449835/74548872-3530fd80-4f81-11ea-89c9-ccbfcea52c59.png">
