### PR TITLE
Allow host as a fallback domain when using variable domain

### DIFF
--- a/src/Storage/DatabaseRequestRepository.php
+++ b/src/Storage/DatabaseRequestRepository.php
@@ -108,7 +108,9 @@ class DatabaseRequestRepository implements RequestRepository
             $route['description'],
             $route['content'],
             [
-                'domain' => $route['domain'],
+                'domain' => $this->hasVariableFragment($route['domain'])
+                    ? request()->getHost()
+                    : $route['domain'],
                 'methods' => $route['methods'],
                 'uri' => $route['uri'],
                 'name' => $route['name'],
@@ -143,5 +145,18 @@ class DatabaseRequestRepository implements RequestRepository
     protected function table($table)
     {
         return DB::connection($this->connection)->table($table);
+    }
+
+    /**
+     * Determines if a given domain has any dynamic fragment.
+     *
+     * @param  string|null  $domain
+     * @return bool
+     */
+    private function hasVariableFragment(?string $domain)
+    {
+        return collect(explode('.', $domain))->filter(function ($fragment) {
+            return Str::startsWith($fragment, '{') && Str::endsWith($fragment,'}');
+        })->count() > 0;
     }
 }

--- a/src/Storage/DatabaseRequestRepository.php
+++ b/src/Storage/DatabaseRequestRepository.php
@@ -156,7 +156,7 @@ class DatabaseRequestRepository implements RequestRepository
     private function hasVariableFragment(?string $domain)
     {
         return collect(explode('.', $domain))->filter(function ($fragment) {
-            return Str::startsWith($fragment, '{') && Str::endsWith($fragment,'}');
+            return Str::startsWith($fragment, '{') && Str::endsWith($fragment, '}');
         })->count() > 0;
     }
 }

--- a/tests/Http/RoutesRequestTest.php
+++ b/tests/Http/RoutesRequestTest.php
@@ -7,6 +7,7 @@ use Davidhsianturi\Compass\Tests\TestCase;
 use Davidhsianturi\Compass\Storage\RouteModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Davidhsianturi\Compass\Storage\DatabaseRequestRepository;
+use Illuminate\Support\Facades\URL;
 
 class RoutesRequestTest extends TestCase
 {
@@ -52,6 +53,19 @@ class RoutesRequestTest extends TestCase
         $this->getJson(route('compass.request.show', $route['id']))
             ->assertSuccessful()
             ->assertExactJson($route);
+    }
+
+    public function test_show_route_request_fallbacks_to_host_for_variable_domain()
+    {
+        $host = 'test.tld.test';
+        URL::forceRootUrl('http://' . $host);
+        $this->registerVariableRoute();
+
+        $route = $this->repository->get()->first()->jsonSerialize();
+
+        $this->getJson(route('compass.request.show', $route['id']))
+            ->assertSuccessful()
+            ->assertJsonFragment(['domain' => $host]);
     }
 
     public function test_store_the_route_request_to_storage()

--- a/tests/Http/RoutesRequestTest.php
+++ b/tests/Http/RoutesRequestTest.php
@@ -3,11 +3,11 @@
 namespace Davidhsianturi\Compass\Tests\Http;
 
 use Davidhsianturi\Compass\Compass;
+use Illuminate\Support\Facades\URL;
 use Davidhsianturi\Compass\Tests\TestCase;
 use Davidhsianturi\Compass\Storage\RouteModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Davidhsianturi\Compass\Storage\DatabaseRequestRepository;
-use Illuminate\Support\Facades\URL;
 
 class RoutesRequestTest extends TestCase
 {
@@ -58,7 +58,7 @@ class RoutesRequestTest extends TestCase
     public function test_show_route_request_fallbacks_to_host_for_variable_domain()
     {
         $host = 'test.tld.test';
-        URL::forceRootUrl('http://' . $host);
+        URL::forceRootUrl('http://'.$host);
         $this->registerVariableRoute();
 
         $route = $this->repository->get()->first()->jsonSerialize();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -93,4 +93,15 @@ class TestCase extends Orchestra
             });
         });
     }
+
+    protected function registerVariableRoute()
+    {
+        RouteFacade::prefix('api/v1')->group(function () {
+            RouteFacade::group(['domain' => '{account}.tld.test'], function () {
+                RouteFacade::get('/test', function () {
+                    return 'test';
+                })->name('vardomain');
+            });
+        });
+    }
 }


### PR DESCRIPTION
This PR allows [variable domains](https://laravel.com/docs/8.x/routing#route-group-subdomain-routing) such as `{account}.domain.test` or `staging.{account}.domain.test` to automatically use the host as a fallback domain.

## Problem Statement
When we use a dynamic subdomain, Compass leaves the domain as it is. So, when we hit the send button, Compass sends the request to the *exact* domain that was fetched from the route definition. Take a look at the screenshot below:

<img width="1440" alt="CompassDomain" src="https://user-images.githubusercontent.com/13091708/120879741-576fe400-c5e7-11eb-97c2-9a6adff5aa27.png">

## Proposed Solution
To mitigate this problem, I am currently checking if the current route definition has a variable fragment anywhere in the domain, if that's the case, then instead of sending the curly-braced URL as domain, send the host address instead:

❌ {account}.domain.test
✅ acme.domain.test